### PR TITLE
Fix: OG images for the writing collection

### DIFF
--- a/src/pages/writing/[id].png.ts
+++ b/src/pages/writing/[id].png.ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+import { generateOgImageForPost } from "@utils/generateOgImages";
+
+// Writing OG images are served at /writing/<id>.png to match the og:image meta
+// built in PostDetails.astro (`/${basePath}/${post.id}.png`). Note: the notes and
+// projects generators live at `[id]/index.png.ts`, which emits `/<coll>/<id>/index.png`
+// and therefore does NOT match their meta URL — those OG images are currently broken.
+export async function getStaticPaths() {
+  const posts = await getCollection("writing").then(p =>
+    p.filter(
+      ({ data }) =>
+        data.status &&
+        (data.status === "published" || data.status === "release") &&
+        !data.ogImage
+    )
+  );
+
+  return posts.map(post => ({
+    params: { id: post.id },
+    props: post,
+  }));
+}
+
+export const GET: APIRoute = async ({ props }) =>
+  new Response(await generateOgImageForPost(props as CollectionEntry<"writing">), {
+    headers: { "Content-Type": "image/png" },
+  });

--- a/src/utils/generateOgImages.tsx
+++ b/src/utils/generateOgImages.tsx
@@ -10,7 +10,7 @@ function svgBufferToPngBuffer(svg: string) {
   return pngData.asPng();
 }
 
-export async function generateOgImageForPost(post: CollectionEntry<"notes">) {
+export async function generateOgImageForPost(post: CollectionEntry<"notes" | "writing">) {
   const svg = await postOgImage(post);
   return new Uint8Array(svgBufferToPngBuffer(svg));
 }

--- a/src/utils/og-templates/post.tsx
+++ b/src/utils/og-templates/post.tsx
@@ -3,7 +3,7 @@ import type { CollectionEntry } from "astro:content";
 import { SITE } from "@config";
 import loadGoogleFonts, { type FontOptions } from "../loadGoogleFont";
 
-export default async (post: CollectionEntry<"notes" | "projects">) => {
+export default async (post: CollectionEntry<"notes" | "projects" | "writing">) => {
   return satori(
     <div
       style={{


### PR DESCRIPTION
## What
Fixes broken OG (social preview) images for the `writing` collection.

`PostDetails.astro` builds `og:image` as `/writing/<slug>.png`, but the writing collection had no OG image endpoint, so every article's social preview 404'd (sharing a post on LinkedIn/email showed a broken card).

## Change
- Add `src/pages/writing/[id].png.ts` — emits `/writing/<slug>.png` (matching the meta), reusing the shared `post` OG template via `generateOgImageForPost`. Filters to `published`/`release` posts without an explicit `ogImage`.
- Widen `generateOgImageForPost` and the `post` template types to accept `writing` entries (they only read base fields already present on writing).

## Known, separate issue (not fixed here)
`notes`/`projects` generators live at `[id]/index.png.ts`, which emits `/<coll>/<id>/index.png` and does NOT match their `/<coll>/<id>.png` meta, so their OG images are broken too. Left for a scoped follow-up.

## Verification
`ci.yml` builds the project on this PR. After merge + deploy, `/writing/<slug>.png` should return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
