### PR TITLE
Tweak OG card: domain instead of duplicate author name

### DIFF
--- a/src/utils/og-templates/post.tsx
+++ b/src/utils/og-templates/post.tsx
@@ -4,6 +4,7 @@ import { SITE } from "@config";
 import loadGoogleFonts, { type FontOptions } from "../loadGoogleFont";
 
 export default async (post: CollectionEntry<"notes" | "projects" | "writing">) => {
+  const domain = SITE.website.replace(/^https?:\/\//, "").replace(/\/$/, "");
   return satori(
     <div
       style={{
@@ -88,7 +89,7 @@ export default async (post: CollectionEntry<"notes" | "projects" | "writing">) =
             </span>
 
             <span style={{ overflow: "hidden", fontWeight: "bold", color: "#e75d0e" }}>
-              {SITE.title}
+              {domain}
             </span>
           </div>
         </div>
@@ -99,7 +100,7 @@ export default async (post: CollectionEntry<"notes" | "projects" | "writing">) =
       height: 630,
       embedFont: true,
       fonts: (await loadGoogleFonts(
-        post.data.title + post.data.author + SITE.title + "by"
+        post.data.title + post.data.author + domain + "by"
       )) as FontOptions[],
     }
   );


### PR DESCRIPTION
## What
The `post` OG-image template showed **"by {author}"** on the left and **`SITE.title`** on the right (orange). Since `author` and `SITE.title` are both "Daniel van der Merwe", the name rendered twice on every card.

## Change
Right-hand (orange) element now shows the **site domain** (derived from `SITE.website`, e.g. `danielvandermerwe.com`) instead of `SITE.title`. Card now reads as byline (left) + source (right). Also added the domain string to the satori font-load set so its glyphs embed.

Shared template, so notes/projects/writing cards all get the fix.

## Verify
`ci.yml` builds on this PR. After merge + deploy, the regenerated card shows the domain on the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
